### PR TITLE
Add ground_plane model

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ for robot_name in m.get_robot_names():
 
 | Robot Name | Screenshot |
 | ---------- | ---------- |
-|            |            |
+| `ground_plane` | <img src="https://user-images.githubusercontent.com/469199/73735685-f3fa4b80-473f-11ea-897d-28fcac85f8a6.png" height="300"> |
 

--- a/gym_ignition_extra_models/ground_plane/ground_plane.sdf
+++ b/gym_ignition_extra_models/ground_plane/ground_plane.sdf
@@ -1,0 +1,35 @@
+<sdf version='1.7'>
+    <model name="ground_plane">
+        <static>true</static>
+        <link name="link">
+            <collision name="collision">
+                <geometry>
+                    <plane>
+                        <normal>0 0 1</normal>
+                    </plane>
+                </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>100</mu>
+                            <mu2>50</mu2>
+                        </ode>
+                    </friction>
+                </surface>
+            </collision>
+            <visual name="visual">
+                <geometry>
+                    <plane>
+                        <normal>0 0 1</normal>
+                        <size>100 100</size>
+                    </plane>
+                </geometry>
+                <material>
+                    <ambient>0.8 0.8 0.8 1</ambient>
+                    <diffuse>0.8 0.8 0.8 1</diffuse>
+                    <specular>0.8 0.8 0.8 1</specular>
+                </material>
+            </visual>
+        </link>
+    </model>
+</sdf>

--- a/gym_ignition_extra_models/ground_plane/model.config
+++ b/gym_ignition_extra_models/ground_plane/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+    <name>ground_plane</name>
+    <version>1.0</version>
+    <sdf version="1.7">ground_plane.sdf</sdf>
+
+    <author>
+        <name>Diego Ferigo</name>
+        <email>diego.ferigo@iit.it</email>
+    </author>
+
+    <description>
+        Model of an empty ground plane.
+    </description>
+</model>

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
       'meshes/**/**/*.*',
       '*/meshes/*.*',
       '*/meshes/**/**/*.*',
+      '*/*.sdf',
       '*/*.urdf',
       '*/model.config',
     ]},

--- a/worlds/empty.world
+++ b/worlds/empty.world
@@ -1,0 +1,98 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+    <world name="default">
+        <physics default="true" type="dart">
+            <max_step_size>0.001</max_step_size>
+            <real_time_factor>1.0</real_time_factor>
+        </physics>
+        <plugin
+                filename="libignition-gazebo-physics-system.so"
+                name="ignition::gazebo::systems::Physics">
+        </plugin>
+        <plugin
+                filename="libignition-gazebo-scene-broadcaster-system.so"
+                name="ignition::gazebo::systems::SceneBroadcaster">
+        </plugin>
+
+        <gui fullscreen="0">
+            <!-- 3D scene -->
+            <plugin filename="GzScene3D" name="3D View">
+                <ignition-gui>
+                    <title>3D View</title>
+                    <property type="bool" key="showTitleBar">false</property>
+                    <property type="string" key="state">docked</property>
+                </ignition-gui>
+                <engine>ogre</engine>
+                <scene>scene</scene>
+                <ambient_light>0.4 0.4 0.4</ambient_light>
+                <background_color>0.8 0.8 0.8</background_color>
+                <camera_pose>2 0 2 0 0.5 3.14</camera_pose>
+                <service>/world/default/scene/info</service>
+                <pose_topic>/world/default/pose/info</pose_topic>
+            </plugin>
+
+            <!-- World control -->
+            <plugin filename="WorldControl" name="World control">
+                <ignition-gui>
+                    <title>World control</title>
+                    <property type="bool" key="showTitleBar">false</property>
+                    <property type="bool" key="resizable">false</property>
+                    <property type="double" key="height">72</property>
+                    <property type="double" key="width">121</property>
+                    <property type="double" key="z">1</property>
+                    <property type="string" key="state">floating</property>
+                    <anchors target="3D View">
+                        <line own="left" target="left"/>
+                        <line own="bottom" target="bottom"/>
+                    </anchors>
+                </ignition-gui>
+                <play_pause>true</play_pause>
+                <step>true</step>
+                <start_paused>true</start_paused>
+                <service>/world/default/control</service>
+                <stats_topic>/world/default/stats</stats_topic>
+            </plugin>
+
+            <!-- World statistics -->
+            <plugin filename="WorldStats" name="World stats">
+                <ignition-gui>
+                    <title>World stats</title>
+                    <property type="bool" key="showTitleBar">false</property>
+                    <property type="bool" key="resizable">false</property>
+                    <property type="double" key="height">110</property>
+                    <property type="double" key="width">290</property>
+                    <property type="double" key="z">1</property>
+                    <property type="string" key="state">floating</property>
+                    <anchors target="3D View">
+                        <line own="right" target="right"/>
+                        <line own="bottom" target="bottom"/>
+                    </anchors>
+                </ignition-gui>
+                <sim_time>true</sim_time>
+                <real_time>true</real_time>
+                <real_time_factor>true</real_time_factor>
+                <iterations>true</iterations>
+                <topic>/world/default/stats</topic>
+            </plugin>
+        </gui>
+
+        <light type="directional" name="sun">
+            <cast_shadows>true</cast_shadows>
+            <pose>0 0 10 0 0 0</pose>
+            <diffuse>1 1 1 1</diffuse>
+            <specular>0.5 0.5 0.5 1</specular>
+            <attenuation>
+                <range>1000</range>
+                <constant>0.9</constant>
+                <linear>0.01</linear>
+                <quadratic>0.001</quadratic>
+            </attenuation>
+            <direction>-0.5 0.1 -0.9</direction>
+        </light>
+
+        <include>
+            <uri>ground_plane</uri>
+        </include>
+
+    </world>
+</sdf>


### PR DESCRIPTION
This `ground_plane` model can be shared by `*.world` files used to visualize and debug models of this repo.

I created an example `empty.world` file to show how to include the ground plane in a world.

![ground_plane](https://user-images.githubusercontent.com/469199/73735685-f3fa4b80-473f-11ea-897d-28fcac85f8a6.png)
